### PR TITLE
Fix Node workflow cache path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
       - name: Install dependencies
         run: npm ci
         working-directory: frontend


### PR DESCRIPTION
## Summary
- point `actions/setup-node` cache to frontend lockfile

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js' because deps are not installed in offline env)*
- `pytest` *(fails: command not found)*
