### PR TITLE
Update docs for GitHub Pages deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ This repository contains a React frontend located in the `frontend/` directory.
 
 ## Deployment
 
-The site is automatically built and deployed to **GitHub Pages** whenever changes are pushed to the `main` branch. The workflow configuration lives in `.github/workflows/deploy.yml`.
+The site is automatically built and deployed to **GitHub Pages** whenever changes are pushed to the `main` branch. The workflow configuration lives in `.github/workflows/deploy.yml`. GitHub Pages hosts the production website, while GitHub Actions provides the continuous integration and deployment pipeline.
 
 The project uses **Node.js 22**. Ensure this version is installed locally so commands like `npm run build` behave consistently with the CI workflow.

--- a/_human_instructions.md
+++ b/_human_instructions.md
@@ -10,3 +10,4 @@ npm install
 Ensure **Node.js 22** is installed locally before running development or build commands.
 
 To enable automatic deployments, configure **GitHub Pages** in the repository settings and choose *GitHub Actions* as the source.
+The site will be hosted directly from GitHub Pages, with GitHub Actions running the build and deployment pipeline whenever changes land on `main`.

--- a/docs/06_Deployment_v1.md
+++ b/docs/06_Deployment_v1.md
@@ -1,0 +1,8 @@
+# Deployment Plan (Version 1)
+
+The website is hosted on **GitHub Pages**. A GitHub Actions workflow (`.github/workflows/deploy.yml`) builds the frontend and publishes the static files to Pages whenever commits reach the `main` branch.
+
+1. **Build Step** – The workflow installs dependencies, runs `npm run build` and uploads the resulting `dist/` folder as an artifact.
+2. **Deploy Step** – The `deploy-pages` action publishes the artifact to GitHub Pages.
+
+This setup provides a lightweight CI/CD pipeline with no separate servers to manage.


### PR DESCRIPTION
## Summary
- clarify in README that GitHub Pages hosts the site and GitHub Actions runs CI/CD
- explain hosting pipeline in `_human_instructions.md`
- add a deployment plan document describing the workflow

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run build` *(fails: cannot find module 'react')*