### PR TITLE
Update README with local dev steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,22 @@
 
 This repository contains a React frontend located in the `frontend/` directory.
 
+## Local Development
+
+Run the app locally with the following commands:
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+You can also batch‑transcribe audio files using `content_generation/transcribe_audio_folder.py`:
+
+```bash
+python content_generation/transcribe_audio_folder.py
+```
+
 ## Deployment
 
 The site is automatically built and deployed to **GitHub Pages** whenever changes are pushed to the `main` branch. The workflow configuration lives in `.github/workflows/deploy.yml`. GitHub Pages hosts the production website, while GitHub Actions provides the continuous integration and deployment pipeline.

--- a/_human_instructions.md
+++ b/_human_instructions.md
@@ -5,6 +5,7 @@ Run the following commands with network access before development:
 ```bash
 cd frontend
 npm install
+npm run dev
 ```
 
 Ensure **Node.js 22** is installed locally before running development or build commands.


### PR DESCRIPTION
## Summary
- document how to run the frontend locally
- point to the audio transcription script
- note running the dev server in human instructions

## Testing
- `npm install` *(fails: Exit handler never called)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*