### PR TITLE
Add guidelines for internet-based setup steps

### DIFF
--- a/MUST_FOLLOW_ON_EVERY_CHANGE_IN_THIS_CODEBASE.md
+++ b/MUST_FOLLOW_ON_EVERY_CHANGE_IN_THIS_CODEBASE.md
@@ -3,4 +3,8 @@
 context: Every time a change is made to the codebase, the environment is setup. The access to internet is only available during this environment setup phase. During this phase, the instructions inside _setup_instructions.txt will be executed automatically by the environment. You (changing the codebase and doing whatever tasks that you are doing) will never have access to the internet throughout your development time doing the task.
 
 - continue to update and maintain _setup_instructions.txt file.
+- If any step requires internet access, STOP immediately.
+  Document the required commands in `_setup_instructions.txt`
+  (for automatic setup) or `_human_instructions.md`
+  (for manual actions). Do not attempt the command yourself.
 - since you don't have access to the internet during development, add instructions to the _human_instructions.md file. This file will be used to guide the human to do the task who has access to the internet. Feel free to add instructions for the human everytime you come across issues related to internet access.


### PR DESCRIPTION
## Summary
- document how to handle steps that need internet access in `MUST_FOLLOW_ON_EVERY_CHANGE_IN_THIS_CODEBASE.md`

## Testing
- `pytest` *(fails: command not found)*