### PR TITLE
Add Monaco editor to frontend

### DIFF
--- a/_setup_instructions.txt
+++ b/_setup_instructions.txt
@@ -1,6 +1,7 @@
 nvm install 22
 cd frontend
 npm install
+npm install @monaco-editor/react
 cd ..
 pip install -r requirements.txt
 apt-get install ffmpeg

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@monaco-editor/react": "^4.7.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -1048,6 +1049,29 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.5.0.tgz",
+      "integrity": "sha512-hKoGSM+7aAc7eRTRjpqAZucPmoNOC4UUbknb/VNoTkEIkCPhqV8LfbsgM1webRM7S/z21eHEx9Fkwx8Z/C/+Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
+      "integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.5.0"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -3306,6 +3330,13 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/monaco-editor": {
+      "version": "0.52.2",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
+      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3700,6 +3731,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
+      "license": "MIT"
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,9 +10,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@monaco-editor/react": "^4.7.0",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0",
-    "@monaco-editor/react": "^4.8.3"
+    "react-dom": "^19.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "@monaco-editor/react": "^4.8.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -15,8 +15,14 @@
 .selector button.active {
   font-weight: bold;
 }
-.editor textarea {
+.editor {
   width: 400px;
+}
+
+.editor .monaco-editor,
+.editor .monaco-editor-background {
+  width: 100%;
+  height: 100%;
 }
 .settings, .details, .issues {
   border: 1px solid #ccc;

--- a/frontend/src/components/CodeEditor.tsx
+++ b/frontend/src/components/CodeEditor.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import MonacoEditor from '@monaco-editor/react'
 import type { Question } from './questionData'
 
 interface Props {
@@ -11,9 +12,10 @@ interface Props {
 export default function CodeEditor({ question, code, onChange, onCheck }: Props) {
   const [local, setLocal] = useState(code)
 
-  function handleChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
-    setLocal(e.target.value)
-    onChange(e.target.value)
+  function handleChange(value: string | undefined) {
+    const val = value ?? ''
+    setLocal(val)
+    onChange(val)
   }
 
   function handleCheck() {
@@ -26,7 +28,13 @@ export default function CodeEditor({ question, code, onChange, onCheck }: Props)
 
   return (
     <div className="editor">
-      <textarea value={local} onChange={handleChange} rows={20} cols={60} />
+      <MonacoEditor
+        value={local}
+        language="python"
+        onChange={handleChange}
+        options={{ automaticLayout: true }}
+        className="h-96 w-full"
+      />
       <div>
         <button id="check-btn" onClick={handleCheck}>Check</button>
       </div>

--- a/frontend/src/types/monaco-editor-react.d.ts
+++ b/frontend/src/types/monaco-editor-react.d.ts
@@ -1,0 +1,16 @@
+declare module '@monaco-editor/react' {
+  import * as React from 'react'
+  export interface OnChange {
+    (value: string | undefined, event?: any): void
+  }
+  export interface MonacoEditorProps {
+    value?: string
+    language?: string
+    height?: string | number
+    width?: string | number
+    onChange?: OnChange
+    options?: Record<string, unknown>
+    className?: string
+  }
+  export default function MonacoEditor(props: MonacoEditorProps): React.ReactElement
+}

--- a/frontend/src/types/monaco-editor-react.d.ts
+++ b/frontend/src/types/monaco-editor-react.d.ts
@@ -1,7 +1,9 @@
+import * as monaco from 'monaco-editor';
+
 declare module '@monaco-editor/react' {
   import * as React from 'react'
   export interface OnChange {
-    (value: string | undefined, event?: any): void
+    (value: string | undefined, event?: monaco.editor.IModelContentChangedEvent): void
   }
   export interface MonacoEditorProps {
     value?: string


### PR DESCRIPTION
## Summary
- install `@monaco-editor/react` dependency
- document the install step in setup instructions
- add basic type declaration for the new package
- replace textarea with Monaco editor
- update editor CSS for Monaco

## Testing
- `npm run lint`
- `npm run build` *(fails: cannot resolve `@monaco-editor/react` without network)*