### PR TITLE
Add lint-staged precommit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged

--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ npm install
 npm run dev
 ```
 
+## Development
+
+This project uses **husky** and **lint-staged** to lint staged TypeScript files
+before each commit. After installing dependencies in `frontend/`, run
+`npm run prepare` once to set up the Git hooks. The generated pre‑commit hook
+executes `lint-staged`, which runs ESLint on staged `src/**/*.ts` and
+`src/**/*.tsx` files.
+
 You can also batch‑transcribe audio files using `content_generation/transcribe_audio_folder.py`:
 
 ```bash

--- a/frontend/lint-staged.config.js
+++ b/frontend/lint-staged.config.js
@@ -1,0 +1,3 @@
+export default {
+  "src/**/*.{ts,tsx}": "npm run lint"
+};


### PR DESCRIPTION
## Summary
- add husky pre-commit hook that runs `lint-staged`
- configure `lint-staged` to lint TS/TSX source files
- document new husky/lint-staged workflow

## Testing
- `npm run lint`
- `npm run build`
