### PR TITLE
Add lint/build pre-commit hook

### DIFF
--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+echo "husky - DEPRECATED\n\nPlease remove the following two lines from $0:\n\n#!/usr/bin/env sh\n. \"$(dirname -- \"$0\")/_/husky.sh\"\n\nThey WILL FAIL in v10.0.0\n"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,4 @@
-npx lint-staged
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npm run lint && npm run build

--- a/README.md
+++ b/README.md
@@ -19,11 +19,10 @@ npm run dev
 
 ## Development
 
-This project uses **husky** and **lint-staged** to lint staged TypeScript files
-before each commit. After installing dependencies in `frontend/`, run
-`npm run prepare` once to set up the Git hooks. The generated pre‑commit hook
-executes `lint-staged`, which runs ESLint on staged `src/**/*.ts` and
-`src/**/*.tsx` files.
+This project uses **husky** to run `npm run lint && npm run build` before each
+commit. After installing dependencies in `frontend/`, run `npm run prepare`
+once to set up the Git hooks. The generated pre‑commit hook ensures both the
+lint step and production build succeed locally before the commit is allowed.
 
 You can also batch‑transcribe audio files using `content_generation/transcribe_audio_folder.py`:
 


### PR DESCRIPTION
## Summary
- add Husky hook script and configure hooks path
- run `npm run lint && npm run build` before commits
- document new pre-commit behaviour in README

## Testing
- `npm run lint`
- `npm run build`
