### PR TITLE
Implement validateSolution utility

### DIFF
--- a/frontend/src/components/CodeEditor.tsx
+++ b/frontend/src/components/CodeEditor.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 
 import MonacoEditor from '@monaco-editor/react'
 import type { Question } from './questionData'
+import { validateSolution } from '../utils/validateSolution'
 
 interface Props {
   question: Question
@@ -24,10 +25,7 @@ export default function CodeEditor({ question, code, onChange, onCheck }: Props)
   }
 
   function handleCheck() {
-    const issues: string[] = []
-    if (local.trim() !== question.solution.trim()) {
-      issues.push('Solution does not match exactly.')
-    }
+    const issues = validateSolution(question, local)
     onCheck(issues)
   }
 

--- a/frontend/src/utils/validateSolution.ts
+++ b/frontend/src/utils/validateSolution.ts
@@ -1,0 +1,20 @@
+import type { Question } from '../components/questionData'
+
+/**
+ * Validate the given code against the question's solution.
+ *
+ * Returns an array of issue messages if the provided code does not
+ * exactly match the expected solution. The array will be empty when
+ * the code passes all checks.
+ *
+ * @param question - The question to validate against.
+ * @param code - The candidate solution code.
+ * @returns A list of issues found while validating.
+ */
+export function validateSolution(question: Question, code: string): string[] {
+  const issues: string[] = []
+  if (code.trim() !== question.solution.trim()) {
+    issues.push('Solution does not match exactly.')
+  }
+  return issues
+}


### PR DESCRIPTION
## Summary
- add a `validateSolution` helper with JSDoc
- use `validateSolution` in `CodeEditor`

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*