### PR TITLE
Implement slide-in panels

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,9 @@ function App() {
   // persistent progress backed by localStorage via custom hook
   const [progress, setProgress] = usePersistentProgress()
   const [issues, setIssues] = useState<string[]>([])
+  const [showSelector, setShowSelector] = useState(false)
+  const [showSettings, setShowSettings] = useState(false)
+  const [showIssues, setShowIssues] = useState(false)
 
   const current = questions.find(q => q.id === progress.selected) || questions[0]
 
@@ -44,19 +47,43 @@ function App() {
 
   return (
     <div className="app">
+      <div
+        className="fixed top-0 left-0 h-full w-1"
+        onMouseEnter={() => setShowSelector(true)}
+        onMouseLeave={() => setShowSelector(false)}
+      />
+      <div
+        className="fixed top-0 right-0 h-full w-1"
+        onMouseEnter={() => setShowSettings(true)}
+        onMouseLeave={() => setShowSettings(false)}
+      />
+      <div
+        className="fixed bottom-0 left-0 w-full h-1"
+        onMouseEnter={() => setShowIssues(true)}
+        onMouseLeave={() => setShowIssues(false)}
+      />
       <QuestionSelector
         questions={questions}
         current={current.id}
         onSelect={id => setProgress(p => ({ ...p, selected: id }))}
+        visible={showSelector}
+        onMouseLeave={() => setShowSelector(false)}
       />
       <QuestionDetails question={current} />
       <CodeEditor
         question={current}
         code={progress.codes[current.id] || current.starter}
         onChange={setCode}
-        onCheck={setIssues}
+        onCheck={iss => {
+          setIssues(iss)
+          if (iss.length > 0) setShowIssues(true)
+        }}
       />
-      <IssuePanel issues={issues} />
+      <IssuePanel
+        issues={issues}
+        visible={showIssues}
+        onMouseLeave={() => setShowIssues(false)}
+      />
       <SettingsSidebar
         mode={progress.mode}
         onModeChange={mode => setProgress(p => ({ ...p, mode }))}
@@ -69,6 +96,8 @@ function App() {
             console.error('Failed to parse progress data from local storage:', e)
           }
         }}
+        visible={showSettings}
+        onMouseLeave={() => setShowSettings(false)}
       />
       <VoiceButton onCommand={handleCommand} /> {/* voice recognition */}
     </div>

--- a/frontend/src/components/IssuePanel.tsx
+++ b/frontend/src/components/IssuePanel.tsx
@@ -3,10 +3,19 @@
  *
  * The panel is hidden when the issue array is empty.
  */
-export default function IssuePanel({ issues }: { issues: string[] }) {
+interface Props {
+  issues: string[]
+  visible?: boolean
+  onMouseLeave?: React.MouseEventHandler<HTMLElement>
+}
+
+export default function IssuePanel({ issues, visible = false, onMouseLeave }: Props) {
   if (issues.length === 0) return null
   return (
-    <aside className="issues">
+    <aside
+      onMouseLeave={onMouseLeave}
+      className={`issues fixed bottom-0 left-0 right-0 bg-white transform transition-transform ${visible ? 'translate-y-0' : 'translate-y-full'}`}
+    >
       <h3>Issues</h3>
       <ul>
         {issues.map((iss, i) => (

--- a/frontend/src/components/QuestionSelector.tsx
+++ b/frontend/src/components/QuestionSelector.tsx
@@ -4,14 +4,25 @@ interface Props {
   questions: Question[]
   current: number
   onSelect: (id: number) => void
+  visible?: boolean
+  onMouseLeave?: React.MouseEventHandler<HTMLElement>
 }
 /**
  * List all questions and allow one to be selected.
  */
 
-export default function QuestionSelector({ questions, current, onSelect }: Props) {
+export default function QuestionSelector({
+  questions,
+  current,
+  onSelect,
+  visible = false,
+  onMouseLeave,
+}: Props) {
   return (
-    <aside className="selector">
+    <aside
+      onMouseLeave={onMouseLeave}
+      className={`selector fixed top-0 left-0 h-full bg-white transform transition-transform ${visible ? 'translate-x-0' : '-translate-x-full'}`}
+    >
       <ul>
         {questions.map(q => (
           <li key={q.id}>

--- a/frontend/src/components/SettingsSidebar.tsx
+++ b/frontend/src/components/SettingsSidebar.tsx
@@ -3,12 +3,21 @@ interface Props {
   onModeChange: (mode: string) => void
   onExport: () => void
   onImport: (data: string) => void
+  visible?: boolean
+  onMouseLeave?: React.MouseEventHandler<HTMLElement>
 }
 
 /**
  * Sidebar for switching modes and importing/exporting progress.
  */
-export default function SettingsSidebar({ mode, onModeChange, onExport, onImport }: Props) {
+export default function SettingsSidebar({
+  mode,
+  onModeChange,
+  onExport,
+  onImport,
+  visible = false,
+  onMouseLeave,
+}: Props) {
   function handleUpload(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0]
     if (!file) return
@@ -22,7 +31,10 @@ export default function SettingsSidebar({ mode, onModeChange, onExport, onImport
   }
 
   return (
-    <aside className="settings">
+    <aside
+      onMouseLeave={onMouseLeave}
+      className={`settings fixed top-0 right-0 h-full bg-white transform transition-transform ${visible ? 'translate-x-0' : 'translate-x-full'}`}
+    >
       <h3>Settings</h3>
       <label>
         Mode:


### PR DESCRIPTION
## Summary
- add `visible` state prop to `QuestionSelector`, `SettingsSidebar`, and `IssuePanel`
- expose optional `onMouseLeave` handlers on panels
- manage panel visibility from `App` and show edges that toggle them
- reveal `IssuePanel` after running code checks

## Testing
- `npm run lint`
- `npm run build`
